### PR TITLE
3.32 Support

### DIFF
--- a/pixel-saver@deadalnix.me/buttons.js
+++ b/pixel-saver@deadalnix.me/buttons.js
@@ -216,7 +216,7 @@ function updateVisibility() {
 		visible = false;
 		let win = Util.getWindow();
 		if (win) {
-			visible = win.decorated;
+			visible = !win.decorated;
 		}
 	}
 	

--- a/pixel-saver@deadalnix.me/util.js
+++ b/pixel-saver@deadalnix.me/util.js
@@ -14,13 +14,13 @@ var DisplayWrapper = {
     },
      getMonitorManager: function() {
         return global.screen || Meta.MonitorManager.get();
-	},
-	getWindowManager: function() {
-		return global.screen || global.window_manager;
-	},
-	getDisplay: function() {
-		return global.screen || global.display;
-	}
+    },
+     getWindowManager: function() {
+	return global.screen || global.window_manager;
+    },
+     getDisplay: function() {
+	return global.screen || global.display;
+    }
 };
 
 function getWindow() {

--- a/pixel-saver@deadalnix.me/util.js
+++ b/pixel-saver@deadalnix.me/util.js
@@ -14,7 +14,13 @@ var DisplayWrapper = {
     },
      getMonitorManager: function() {
         return global.screen || Meta.MonitorManager.get();
-    }
+	},
+	getWindowManager: function() {
+		return global.screen || global.window_manager;
+	},
+	getDisplay: function() {
+		return global.screen || global.display;
+	}
 };
 
 function getWindow() {


### PR DESCRIPTION
Hi I think I managed to fix the issue where all windows are stripped off their title bar from #191 3.32 should be supported now.

I now check if the windows are maximized in a new event called `onWindowChanged(win)` which is called when the focus is changed or size of a window changes. If it is maximized I hide the title bar, otherwise I show it again.

The issue here is that it also adds title bars to windows that didn't have them before such as steam etc. so now I also check the original window state before changing the title bar in `ignoreWindow(win)`.

It seems to work fine for me but I didn't thoroughly test it yet so there may be issues. I took a lot of inspiration from [this code](https://github.com/hardpixel/unite-shell/blob/0f0ce42543ce417840f6005864ad9f2fcce2bff3/unite%40hardpixel.eu/modules/windowDecoration.js)