### PR TITLE
Revert "added check in case ":" is not present in wm preference."

### DIFF
--- a/pixel-saver@deadalnix.me/buttons.js
+++ b/pixel-saver@deadalnix.me/buttons.js
@@ -45,7 +45,7 @@ function createButtons() {
 	let order = new Gio.Settings({schema_id: DCONF_META_PATH}).get_string('button-layout');
 	LOG('Buttons layout : ' + order);
 	
-	if (order.indexOf(':') == -1 && order.length <= 1) {
+	if (order.indexOf(':') == -1) {
 		LOG('Button layout empty')
 		return
 	}


### PR DESCRIPTION
Requiring `order.length <= 1` for an empty layout implies to consider layouts like `appmenu:` non-empty.