### PR TITLE
Replace use of tweener with clutter

### DIFF
--- a/pixel-saver@deadalnix.me/app_menu.js
+++ b/pixel-saver@deadalnix.me/app_menu.js
@@ -3,7 +3,6 @@ const Main = imports.ui.main;
 const Mainloop = imports.mainloop;
 const Shell = imports.gi.Shell;
 const St = imports.gi.St;
-const Tweener = imports.tweener.tweener;
 
 const ExtensionUtils = imports.misc.extensionUtils;
 const Me = ExtensionUtils.getCurrentExtension();
@@ -157,11 +156,11 @@ function onAppMenuHover(actor) {
 			
 			LOG('show title tooltip');
 			
-			Tweener.removeTweens(tooltip);
-			Tweener.addTween(tooltip, {
+			tooltip.remove_all_transitions();
+			tooltip.ease({
 				opacity: 255,
 				time: SHOW_DURATION,
-				transition: 'easeOutQuad',
+				transition: Clutter.AnimationMode.EASE_OUT_QUAD,
 			});
 			
 			return false;
@@ -172,11 +171,11 @@ function onAppMenuHover(actor) {
 		
 		resetMenuCallback();
 		
-		Tweener.removeTweens(tooltip);
-		Tweener.addTween(tooltip, {
+		tooltip.remove_all_transitions();
+		tooltip.ease({
 			opacity: 0,
 			time: HIDE_DURATION,
-			transition: 'easeOutQuad',
+			transition: Clutter.AnimationMode.EASE_OUT_QUAD,
 			onComplete: function() {
 				Main.uiGroup.remove_actor(tooltip);
 			}


### PR DESCRIPTION
Tweener is removed in the upcomming gnome 3.38. I think we can improve cceefae50cf85f725385c492d756f4e3257473b7 and completely replace tweener with clutter animations.

According to latest patches in gnome-shell, this will improve performance in animations rendering:
https://gitlab.gnome.org/GNOME/gnome-shell/-/merge_requests/22
https://gitlab.gnome.org/GNOME/gnome-shell/-/merge_requests/669

Please check it carefully. I don't see any possible issues, but I'm new in gnome-shell development.