### PR TITLE
Move restarting GNOME Shell to earlier in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -79,6 +79,9 @@ In the meantime, you can install the extension manually.
     # copy to extensions directory
     cp -r pixel-saver@deadalnix.me -t ~/.local/share/gnome-shell/extensions
 
+    # You may need to reload GNOME Shell to recognise new extension by
+    # hitting Alt + F2 and entering "r"
+
     # activate 
     # GNOME <3.38
     gnome-shell-extension-tool -e pixel-saver@deadalnix.me
@@ -86,9 +89,6 @@ In the meantime, you can install the extension manually.
     gnome-extensions enable pixel-saver@deadalnix.me
 
 ```
-
-At last, remember to reload GNOME Shell
-by pressing <kbd>Alt</kbd> + <kbd>F2</kbd> and entering <kbd>r</kbd> .
 
 ### Dependencies
 


### PR DESCRIPTION
First up, thanks for making this extension!

I found when installing the extension that I needed to restart GNOME Shell before the extension could be enabled. I have moved the instruction to do this in the README to reflect this.