### PR TITLE
Fix JS ERROR: ReferenceError: Clutter is not defined

### DIFF
--- a/pixel-saver@deadalnix.me/app_menu.js
+++ b/pixel-saver@deadalnix.me/app_menu.js
@@ -3,6 +3,7 @@ const Main = imports.ui.main;
 const Mainloop = imports.mainloop;
 const Shell = imports.gi.Shell;
 const St = imports.gi.St;
+const Clutter = imports.gi.Clutter;
 
 const ExtensionUtils = imports.misc.extensionUtils;
 const Me = ExtensionUtils.getCurrentExtension();


### PR DESCRIPTION
`abr 08 04:21:31 ArchLinuxRui gnome-shell[50683]: JS ERROR: ReferenceError: Clutter is not defined onAppMenuHover@/~/.local/share/gnome-shell/extensions/pixel-saver@deadalnix.me/app_menu.js:178:4`

This error is sometimes print in the journalctl, look inside **app_menu.js** Clutter is used twice, but it is never defined. 