### PR TITLE
fix shell version for minor versions

### DIFF
--- a/pixel-saver@deadalnix.me/metadata.json
+++ b/pixel-saver@deadalnix.me/metadata.json
@@ -3,5 +3,5 @@
 	"name": "Pixel Saver",
 	"description": "Pixel Saver is designed to save pixel by fusing activity bar and title bar in a natural way",
 	"url": "https://github.com/deadalnix/pixel-saver",
-	"shell-version": ["3.34", "3.36", "3.38", "40.0", "40.1", "40.2", "40.3", "41.0", "41.1", "41.2", "41.3", "42.0"]
+	"shell-version": ["3.34", "3.36", "3.38", "40", "41", "42"]
 }


### PR DESCRIPTION
On GNOME Shell 40 and higher major version would be enough. By only using major version, all minor versions will be supported.

For example, _"40"_ Means 40.0, 40.1, 40.2, ... are supported.

Read the [GNOME Shell Extensions Review Guidelines](https://gjs.guide/extensions/review-guidelines/review-guidelines.html#metadata-json-must-be-well-formed) for that.