### PR TITLE
Adding 44 to metadata.json

### DIFF
--- a/pixel-saver@deadalnix.me/metadata.json
+++ b/pixel-saver@deadalnix.me/metadata.json
@@ -3,5 +3,5 @@
 	"name": "Pixel Saver",
 	"description": "Pixel Saver is designed to save pixel by fusing activity bar and title bar in a natural way",
 	"url": "https://github.com/deadalnix/pixel-saver",
-	"shell-version": ["3.34", "3.36", "3.38", "40", "41", "42", "43"]
+	"shell-version": ["3.34", "3.36", "3.38", "40", "41", "42", "43", "44"]
 }


### PR DESCRIPTION
Adding 44 to metadata.json

Pixel saver seems to be working flawlessly on GNOME 44.

Tested on ArchLinux + GNOME 44
Tested on Debian Bullseye + GNOME 44